### PR TITLE
Update PhiClient.cs

### DIFF
--- a/Source/PhiClient/PhiClient.cs
+++ b/Source/PhiClient/PhiClient.cs
@@ -69,7 +69,20 @@ namespace PhiClient
                 Disconnect();
             }
 
-            client = new Client(serverAddress, 16180);
+            // Edited by [NOT-FOUND-404-UI]
+            // ---------------------------------------------------------------
+            int serverPort = new int();
+            if (0 <= serverAddress.IndexOf(":")) {
+                string[] temp = new string[2];
+                temp = serverAddress.Split(':');
+                serverAddress = temp[0];
+                serverPort = int.Parse(temp[1]);
+            } else {
+                serverPort = PORT;
+            }
+            client = new Client(serverAddress, serverPort);
+            // ---------------------------------------------------------------
+            //client = new Client(serverAddress,16180);
             client.Connection += ConnectionCallback;
             client.Message += MessageCallback;
             client.Disconnection += DisconnectCallback;


### PR DESCRIPTION
In the previous method, it was not possible to specify the port number when connecting. 
Performs the process of splitting the server address and server port in recognition of the colon.